### PR TITLE
modify the default regex for `fakeitalic` and `fakesc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-lib.pdf
-testing-f

--- a/lib.typ
+++ b/lib.typ
@@ -1,6 +1,7 @@
-#let fakebold(base-weight: none, s, ..params) = {
-  set text(weight: base-weight) if base-weight != none
-  set text(weight: "regular") if base-weight == none
+#let fakebold(base-weight: auto, s, ..params) = {
+  assert(base-weight in (auto, none, ) or type(base-weight) in (str, int, ), message: "`base-weight` should be `auto`, `none`, `int` or `str` type.")
+  set text(weight: base-weight) if type(base-weight) in (str, int)
+  set text(weight: "regular") if base-weight == auto
   set text(..params) if params != ()
   context {
     set text(stroke: 0.02857em + text.fill)
@@ -8,14 +9,14 @@
   }
 }
 
-#let regex-fakebold(reg-exp: ".", base-weight: none, s, ..params) = {
+#let regex-fakebold(reg-exp: ".+", base-weight: auto, s, ..params) = {
   show regex(reg-exp): it => {
     fakebold(base-weight: base-weight, it, ..params)
   }
   s
 }
 
-#let show-fakebold(reg-exp: ".", base-weight: none, s, ..params) = {
+#let show-fakebold(reg-exp: ".+", base-weight: auto, s, ..params) = {
   show text.where(weight: "bold").or(strong): it => {
     regex-fakebold(reg-exp: reg-exp, base-weight: base-weight, it, ..params)
   }
@@ -40,6 +41,6 @@
 #let fakeitalic(ang: -18.4deg, s) = regex-fakeitalic(ang: ang, s)
 
 #let fakesc(s) = {
-  show regex("[\p{Lu}]"): text.with((10 / 8) * 1em)
+  show regex("\p{Lu}+"): text.with((10 / 8) * 1em)
   text(0.8em, upper(s))
 }

--- a/lib.typ
+++ b/lib.typ
@@ -48,7 +48,7 @@
 
 #let fakesc(s, scaling: 0.75) = {
   show regex("\p{Ll}+"): it => {
-    text(scaling * 1em, upper(it))
+    context text(scaling * 1em, stroke: 0.01em + text.fill, upper(it))
   }
   text(s)
 }

--- a/lib.typ
+++ b/lib.typ
@@ -1,5 +1,8 @@
 #let fakebold(base-weight: auto, s, ..params) = {
-  assert(base-weight in (auto, none, ) or type(base-weight) in (str, int, ), message: "`base-weight` should be `auto`, `none`, `int` or `str` type.")
+  assert(
+    base-weight in (auto, none) or type(base-weight) in (str, int),
+    message: "`base-weight` should be `auto`, `none`, `int` or `str` type.",
+  )
   set text(weight: base-weight) if type(base-weight) in (str, int)
   set text(weight: "regular") if base-weight == auto
   set text(..params) if params != ()
@@ -24,23 +27,28 @@
 }
 
 #let cn-fakebold(s, ..params) = {
-  regex-fakebold(reg-exp: "[\p{script=Han}！-･〇-〰—]", base-weight: "regular", s, ..params)
+  regex-fakebold(reg-exp: "[\p{script=Han}！-･〇-〰—]+", base-weight: "regular", s, ..params)
 }
 
 #let show-cn-fakebold(s, ..params) = {
-  show-fakebold(reg-exp: "[\p{script=Han}！-･〇-〰—]", base-weight: "regular", s, ..params)
+  show-fakebold(reg-exp: "[\p{script=Han}！-･〇-〰—]+", base-weight: "regular", s, ..params)
 }
 
-#let regex-fakeitalic(reg-exp: "\b.+?\b", ang: -18.4deg, s) = {
+#let regex-fakeitalic(reg-exp: ".+?", ang: -18.4deg, s) = {
   show regex(reg-exp): it => {
     box(skew(ax: ang, reflow: false, it))
   }
   s
 }
 
-#let fakeitalic(ang: -18.4deg, s) = regex-fakeitalic(ang: ang, s)
+#let fakeitalic(
+  ang: -18.4deg,
+  s,
+) = regex-fakeitalic(reg-exp: "(?:\b[^\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}！-･〇-〰—]+?\b|[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}])", s)
 
-#let fakesc(s) = {
-  show regex("\p{Lu}+"): text.with((10 / 8) * 1em)
-  text(0.8em, upper(s))
+#let fakesc(s, scaling: 0.75) = {
+  show regex("\p{Ll}+"): it => {
+    text(scaling * 1em, upper(it))
+  }
+  text(s)
 }

--- a/tests/fakebold.typ
+++ b/tests/fakebold.typ
@@ -1,0 +1,66 @@
+#import "../lib.typ": *
+#set page(margin: 2cm)
+#show table.cell.where(y: 0): it => {strong(it)}
+
+// Please add `set text(font: ...)` to test how text appears in different fonts when testing typography layouts.
+
+// Functional tests
+
+#[
+  *Regex `[aik]` Fakebold*: #regex-fakebold(reg-exp: "[aik]", lorem(10)) \
+  *Fakebold based on `bold`*: #fakebold(base-weight: "bold", lorem(10)) \
+]
+
+// English
+
+#[
+  #let en-test(s) = table(
+    columns: (1fr, ) * 3,
+    stroke: 0.5pt,
+    table.header(
+      [Original],
+      [Bold - Font],
+      [Fakebold - `cuti`]
+    ),
+    s,
+    strong(s),
+    fakebold(s)
+  )
+
+  #en-test(lorem(30))
+
+  #set par(justify: true)
+
+  #en-test(lorem(30))
+]
+
+// Chinese + English
+
+#[
+  #let cn-test(s) = table(
+    columns: (1fr, ) * 3,
+    stroke: 0.5pt,
+    table.header(
+      [Original],
+      [Fakebold - `cuti`],
+      [zh Fakebold + en Font Bold]
+    ),
+    s,
+    fakebold(s),
+    show-cn-fakebold(strong(s))
+  )
+
+  #set par(justify: true)
+
+  // zh-CN
+  #set text(lang: "cn", region: "zh")
+  #cn-test[你说得对，但是《Typst》是一款由 Typst GmbH 与众多贡献者开发的一款开放世界冒险排版游戏。游戏发生在一个被称作「typst.app」的线上世界。在这里，后面忘了——同时，逐步发掘排版的真相。Typst，启动！]
+
+  // zh-HK
+  #set text(lang: "cn", region: "hk")
+  #cn-test[你說得對，但是《Typst》係一款由 Typst GmbH 同眾多貢獻者開發嘅開放世界冒險排版遊戲。遊戲發生喺一個叫做「typst.app」嘅線上世界。喺呢度，後面唔記得咗——同時，逐步發掘排版嘅真相。Typst，啟動！]
+
+  // zh-TW
+  #set text(lang: "cn", region: "tw")
+  #cn-test[你說得對，但是《Typst》是一款由 Typst GmbH 與眾多貢獻者開發的開放世界冒險排版遊戲。遊戲發生在一個被稱作「typst.app」的線上世界。在這裡，後面忘記了——同時，逐步發掘排版的真相。Typst，啟動！]
+]

--- a/tests/fakeitalic.typ
+++ b/tests/fakeitalic.typ
@@ -1,0 +1,66 @@
+#import "../lib.typ": *
+#set page(margin: 2cm)
+#show table.cell.where(y: 0): it => {strong(it)}
+
+// Please add `set text(font: ...)` to test how text appears in different fonts when testing typography layouts.
+
+// Functional tests
+
+#[
+  *Fakeitalic*: #fakeitalic(lorem(10))
+]
+
+// English
+
+#[
+  #let en-test(s) = table(
+    columns: (1fr, ) * 3,
+    stroke: 0.5pt,
+    table.header(
+      [Original],
+      [Italic - Font],
+      [Fakeitalic -18.4deg - `cuti`]
+    ),
+    s,
+    emph(s),
+    fakeitalic(s)
+  )
+
+  #en-test(lorem(30))
+
+  #set par(justify: true)
+
+  #en-test(lorem(30))
+]
+
+
+// Chinese + English
+
+#[
+  #let cn-test(s) = table(
+    columns: (1fr, ) * 3,
+    stroke: 0.5pt,
+    table.header(
+      [Original],
+      [Fakebold - `cuti`],
+      [zh Fakebold + en Font Bold]
+    ),
+    s,
+    emph(s),
+    fakeitalic(s)
+  )
+
+  #set par(justify: true)
+
+  // zh-CN
+  #set text(lang: "cn", region: "zh")
+  #cn-test[你说得对，但是《Typst》是一款由 Typst GmbH 与众多贡献者开发的一款开放世界冒险排版游戏。游戏发生在一个被称作「typst.app」的线上世界。在这里，后面忘了——同时，逐步发掘排版的真相。Typst，启动！]
+
+  // zh-HK
+  #set text(lang: "cn", region: "hk")
+  #cn-test[你說得對，但是《Typst》係一款由 Typst GmbH 同眾多貢獻者開發嘅開放世界冒險排版遊戲。遊戲發生喺一個叫做「typst.app」嘅線上世界。喺呢度，後面唔記得咗——同時，逐步發掘排版嘅真相。Typst，啟動！]
+
+  // zh-TW
+  #set text(lang: "cn", region: "tw")
+  #cn-test[你說得對，但是《Typst》是一款由 Typst GmbH 與眾多貢獻者開發的開放世界冒險排版遊戲。遊戲發生在一個被稱作「typst.app」的線上世界。在這裡，後面忘記了——同時，逐步發掘排版的真相。Typst，啟動！]
+]

--- a/tests/fakesc.typ
+++ b/tests/fakesc.typ
@@ -1,0 +1,26 @@
+#import "../lib.typ": *
+#set page(margin: 2cm)
+#show table.cell.where(y: 0): it => {strong(it)}
+
+// Please add `set text(font: ...)` to test how text appears in different fonts when testing typography layouts.
+
+#[
+  #let en-test(s) = table(
+    columns: (1fr, ) * 3,
+    stroke: 0.5pt,
+    table.header(
+      [Original],
+      [Small Capitals - Font],
+      [FakeSC - `cuti`]
+    ),
+    s,
+    smallcaps(s),
+    fakesc(s)
+  )
+
+  #en-test(lorem(30))
+
+  #set par(justify: true)
+
+  #en-test(lorem(30))
+]


### PR DESCRIPTION
- Modify `fakeitalic` to better accommodate CJK characters.
- Modify `fakesc` to better match intuitive expectations.