### PR TITLE
Add show functions to fakeitalic similar to fakebold

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -47,6 +47,24 @@
   s,
 ) = regex-fakeitalic(reg-exp: "(?:\b[^\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}！-･〇-〰—]+?\b|[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}])", ang: ang, s)
 
+#let show-fakeitalic(
+  ang: -18.4deg,
+  s,
+) = {
+  show text.where(style: "italic").or(emph): it => {
+    fakeitalic(ang: ang, it)
+  }
+  s
+}
+
+#let cn-fakeitalic(s) = {
+  regex-fakeitalic(reg-exp: "(?:\b[^\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}！-･〇-〰—]+?\b|[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}])", s)
+}
+
+#let show-cn-fakeitalic(s) = {
+  show-fakeitalic(ang: -18.4deg, s)
+}
+
 #let fakesc(s, scaling: 0.75) = {
   show regex("\p{Ll}+"): it => {
     context text(scaling * 1em, stroke: 0.01em + text.fill, upper(it))


### PR DESCRIPTION
This PR include some `show` functions for fakeitalic. The logic the same as show functions for fakebold. With new `show-fake-fakeitalic` and `show-cn-fakeitalic`, markdown syntex `_` works the same as `*`.